### PR TITLE
Remove OpenClaw and Camera tabs from mobile dashboard

### DIFF
--- a/web-ui/js/dashboard.js
+++ b/web-ui/js/dashboard.js
@@ -467,12 +467,12 @@
       document.getElementById("nnDeviceMapBtn")?.classList.toggle("active", state.deviceMapMode);
       document.getElementById("nnDeviceListBtn")?.classList.toggle("active", !state.deviceMapMode);
       const app = document.getElementById("app");
-      app?.classList.toggle("media-tab-active", state.activeTab === "networks" || state.activeTab === "openclaw" || state.activeTab === "speedtest" || state.activeTab === "cameras" || (state.activeTab === "devices" && state.deviceMapMode));
+      app?.classList.toggle("media-tab-active", state.activeTab === "networks" || state.activeTab === "speedtest" || (state.activeTab === "devices" && state.deviceMapMode));
       if(state.deviceMapMode){ window.nnUpdateDiscoveryMap?.(); }
     }
 
     // ---- Navigation ----
-    const allowedTabs = new Set(["dashboard", "devices", "networks", "tools", "gateway", "openclaw", "speedtest", "cameras"]);
+    const allowedTabs = new Set(["dashboard", "devices", "networks", "tools", "gateway", "speedtest"]);
 
     function setTab(tab, opts = {}){
       const options = opts || {};
@@ -497,7 +497,7 @@
       });
 
       const app = document.getElementById("app");
-      app?.classList.toggle("media-tab-active", resolvedTab === "networks" || resolvedTab === "openclaw" || resolvedTab === "speedtest" || resolvedTab === "cameras" || (resolvedTab === "devices" && state.deviceMapMode));
+      app?.classList.toggle("media-tab-active", resolvedTab === "networks" || resolvedTab === "speedtest" || (resolvedTab === "devices" && state.deviceMapMode));
 
       // Push tab state so Android/WebView back navigates tab history instead of immediately exiting.
       if(!options.fromPop){

--- a/web-ui/ninja_mobile_new.html
+++ b/web-ui/ninja_mobile_new.html
@@ -23,7 +23,7 @@
 
         <div class="brand">
           <div class="brand-badge" id="brandBadge">
-            <video src="new_assets/openclaw_icon.mp4" autoplay loop muted playsinline preload="auto" aria-label="OpenClaw icon" style="width:100%;height:100%;object-fit:cover;border-radius:inherit;display:block;"></video>
+            <img src="new_assets/ninja_icon.png" alt="NET_NiNjA logo" style="width:100%;height:100%;object-fit:cover;border-radius:inherit;display:block;" />
           </div>
           <div style="min-width:0;">
             <div class="brand-title">My Network Control</div>
@@ -485,19 +485,9 @@
         </div>
       </section>
 
-      <!-- OpenClaw tab page: embed the OpenClaw dashboard in an iframe -->
-      <section id="tab-openclaw" class="tab-page media" aria-labelledby="tabbtn-openclaw" style="padding:0;">
-        <!-- The iframe loads openclaw_dash.html from the same directory.  It fills the available space. -->
-        <iframe src="openclaw_dash.html" title="OpenClaw Dashboard" style="width:100%;height:100%;border:none;"></iframe>
-      </section>
       <!-- Speedtest tab page -->
       <section id="tab-speedtest" class="tab-page media" aria-labelledby="tabbtn-speedtest">
         <iframe src="new_assets/ninja_speedtest.html" title="Network Speedtest"></iframe>
-      </section>
-      <!-- Cameras tab page -->
-      <section id="tab-cameras" class="tab-page media" aria-labelledby="tabbtn-cameras">
-        <!-- Load the camera viewer via iframe -->
-        <iframe src="net_ninja_cam.html" title="Cameras"></iframe>
       </section>
     </main>
 
@@ -520,12 +510,6 @@
           <div class="ticon" aria-hidden="true">TL</div>
           <div class="tlabel">Tools</div>
         </button>
-
-        <!-- OpenClaw tab button -->
-        <button class="tabbtn" id="tabbtn-openclaw" data-tab="openclaw">
-          <div class="ticon" aria-hidden="true">OC</div>
-          <div class="tlabel">OpenClaw</div>
-        </button>
         <button class="tabbtn" id="tabbtn-gateway" data-tab="gateway">
           <div class="ticon" aria-hidden="true">GW</div>
           <div class="tlabel">Gateway</div>
@@ -533,11 +517,6 @@
         <button class="tabbtn" id="tabbtn-speedtest" data-tab="speedtest">
           <div class="ticon" aria-hidden="true">SP</div>
           <div class="tlabel">Speedtest</div>
-        </button>
-        <!-- Cameras tab button -->
-        <button class="tabbtn" id="tabbtn-cameras" data-tab="cameras">
-          <div class="ticon" aria-hidden="true">CM</div>
-          <div class="tlabel">Cameras</div>
         </button>
       </div>
     </nav>


### PR DESCRIPTION
### Motivation
- Remove the OpenClaw and Camera modules from the main mobile dashboard UI and bottom navigation so they no longer appear as entry points in the shipped dashboard.
- Keep the change minimal and local to the dashboard markup and tab-routing code to avoid touching build system or backend modules.

### Description
- Removed the OpenClaw and Cameras tab pages (removed `#tab-openclaw` and `#tab-cameras`) from `web-ui/ninja_mobile_new.html` so those pages are no longer rendered.
- Removed the OpenClaw and Cameras bottom nav buttons (`tabbtn-openclaw` and `tabbtn-cameras`) from `web-ui/ninja_mobile_new.html` so they do not appear in the tab bar.
- Replaced the OpenClaw header video badge with a neutral NET_NiNjA icon in `web-ui/ninja_mobile_new.html` to remove OpenClaw branding in the main chrome.
- Updated tab routing and UI state in `web-ui/js/dashboard.js` by removing `openclaw` and `cameras` from `allowedTabs` and from the `media-tab-active` toggles so navigation/state can't resolve to the removed tabs.
- Files changed: `web-ui/ninja_mobile_new.html`, `web-ui/js/dashboard.js`.

### Testing
- Attempted `./gradlew :app:assembleDebug` which failed in this environment due to missing Android SDK configuration (`ANDROID_HOME`/`local.properties`); build could not be validated here.
- Attempted `./gradlew test` and `./gradlew lint`; both failed for the same missing Android SDK location in this environment and therefore could not run.
- Render verification: served the UI locally and captured a browser screenshot of `web-ui/ninja_mobile_new.html` to confirm that OpenClaw and Cameras entries were removed from the bottom nav and the header badge was updated; screenshot artifact saved during run (dashboard_no_openclaw_camera.png).
- Manual checks performed: verified `allowedTabs` no longer includes `openclaw`/`cameras` and that `media-tab-active` logic was updated in `web-ui/js/dashboard.js`.

Notes: no Gradle/AGP/Kotlin versions, package names, modules, or build files were changed; modifications are limited to UI markup and client-side tab routing only. Please run the following locally to fully validate build/test: `./gradlew :app:assembleDebug`, `./gradlew test`, `./gradlew lint`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a699725648328b9b263802a6dd142)